### PR TITLE
Bump versions to rust-dist 0.0.10, cargo-install 0.0.6 and removed version from buildpack.toml

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -2,11 +2,11 @@ description = "A sample Builder for using Rust related CNBs"
 
 [[buildpacks]]
   id = "paketo-community/rust-dist"
-  uri = "docker://paketocommunity/rust-dist:0.0.8"
+  uri = "docker://paketocommunity/rust-dist:0.0.10"
 
 [[buildpacks]]
   id = "paketo-community/cargo-install"
-  uri = "docker://paketocommunity/rust-cargo:0.0.4"
+  uri = "docker://paketocommunity/rust-cargo:0.0.6"
 
 [[buildpacks]]
   id = "paketo-buildpacks/procfile"
@@ -15,8 +15,8 @@ description = "A sample Builder for using Rust related CNBs"
 [[order]]
 
 group = [
-    { id = "paketo-community/rust-dist", version="0.0.8"},
-    { id = "paketo-community/cargo-install", version="0.0.4"},
+    { id = "paketo-community/rust-dist", version="0.0.10"},
+    { id = "paketo-community/cargo-install", version="0.0.6"},
     { id = "paketo-buildpacks/procfile", version="4.0.0", optional=true},
 ]
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -4,7 +4,6 @@ api = "0.4"
   homepage = "https://github.com/paketo-community/rust"
   id = "paketo-community/rust"
   name = "Rust Build Pack"
-  version = "0.0.9"
 
 [metadata]
   include-files = ["buildpack.toml"]
@@ -13,11 +12,11 @@ api = "0.4"
 
   [[order.group]]
     id = "paketo-community/rust-dist"
-    version = "0.0.9"
+    version = "0.0.10"
 
   [[order.group]]
     id = "paketo-community/cargo-install"
-    version = "0.0.5"
+    version = "0.0.6"
 
   [[order.group]]
     id = "paketo-buildpacks/procfile"


### PR DESCRIPTION
@ForestEckhardt I think this will fix the issue publishing that we've had. It fixes buildpack.toml in two ways. It removes the version of the rust cnb (I noticed other meta cnb's don't have this version) and it updates the versions, which didn't happen (possibly cause of the JAM bug you mentioned).

This also updates the builder.toml.