### PR TITLE
Bump versions in buildpack.toml & builder.toml

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -2,22 +2,22 @@ description = "A sample Builder for using Rust related CNBs"
 
 [[buildpacks]]
   id = "paketo-community/rust-dist"
-  uri = "docker://paketocommunity/rust-dist:0.0.10"
+  uri = "docker://paketocommunity/rust-dist:0.0.11"
 
 [[buildpacks]]
   id = "paketo-community/cargo-install"
-  uri = "docker://paketocommunity/cargo-install:0.0.6"
+  uri = "docker://paketocommunity/cargo-install:0.0.7"
 
 [[buildpacks]]
   id = "paketo-buildpacks/procfile"
-  uri = "docker://gcr.io/paketo-buildpacks/procfile:4.0.0"
+  uri = "docker://gcr.io/paketo-buildpacks/procfile:4.1.0"
 
 [[order]]
 
 group = [
-    { id = "paketo-community/rust-dist", version="0.0.10"},
-    { id = "paketo-community/cargo-install", version="0.0.6"},
-    { id = "paketo-buildpacks/procfile", version="4.0.0", optional=true},
+    { id = "paketo-community/rust-dist", version="0.0.11"},
+    { id = "paketo-community/cargo-install", version="0.0.7"},
+    { id = "paketo-buildpacks/procfile", version="4.1.0", optional=true},
 ]
 
 [stack]

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -12,7 +12,7 @@ api = "0.4"
 
   [[order.group]]
     id = "paketo-community/rust-dist"
-    version = "0.0.10"
+    version = "0.0.11"
 
   [[order.group]]
     id = "paketo-community/cargo-install"


### PR DESCRIPTION
Bump versions to pick up rust-dist 0.0.11 and to sync builder.toml with all the latest versions.