### PR TITLE
Add mappers for new pipeline-action

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -1,6 +1,8 @@
 github:
   username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
   token:    ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+  mappers:
+  - '|paketocommunity|paketo-community|'
 
 codeowners:
 - path:  "*"

--- a/.github/workflows/update-draft-release.yml
+++ b/.github/workflows/update-draft-release.yml
@@ -25,6 +25,7 @@ jobs:
               uses: docker://ghcr.io/paketo-buildpacks/actions/draft-release:main
               with:
                 github_token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+                mapper_1: '|paketocommunity|paketo-community|'
                 release_body: ${{ steps.release-drafter.outputs.body }}
                 release_id: ${{ steps.release-drafter.outputs.id }}
                 release_name: ${{ steps.release-drafter.outputs.name }}


### PR DESCRIPTION
The recent upgrade to pipeline-builder switches the generation of release notes from a complicated bash script to a Github action.

https://github.com/paketo-buildpacks/pipeline-builder#draft-release

The draft-release action was failing to look up information for dependent images because of the difference in image and github repo names (i.e. `paketocommunity` vs `paketo-community`). This mapper adjusts the action for that difference.

Resolves #170 