### PR TITLE
Adds syft

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -26,6 +26,10 @@ api = "0.6"
     version = "1.7.0"
 
   [[order.group]]
+    id = "paketo-buildpacks/syft"
+    version = "1.11.3"
+
+  [[order.group]]
     id = "paketo-community/cargo"
     version = "0.5.0"
 

--- a/example-builder.toml
+++ b/example-builder.toml
@@ -9,6 +9,10 @@ description = "A sample Builder for using Rust related CNBs"
   uri = "docker://docker.io/paketocommunity/rust-dist:1.7.0"
 
 [[buildpacks]]
+  id = "paketo-buildpacks/syft"
+  uri = "docker://gcr.io/paketo-buildpacks/syft:1.11.3"
+
+[[buildpacks]]
   id = "paketo-community/cargo"
   uri = "docker://docker.io/paketocommunity/cargo:0.5.0"
 
@@ -23,6 +27,9 @@ description = "A sample Builder for using Rust related CNBs"
 
   [[order.group]]
     id = "paketo-community/rust-dist"
+
+  [[order.group]]
+    id = "paketo-buildpacks/syft"
 
   [[order.group]]
     id = "paketo-community/cargo"

--- a/package.toml
+++ b/package.toml
@@ -1,4 +1,3 @@
-
 [[dependencies]]
   uri = "docker://docker.io/paketocommunity/rustup:1.3.0"
 
@@ -10,3 +9,6 @@
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/procfile:5.1.2"
+
+[[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/syft:1.11.3"


### PR DESCRIPTION
Support was added to the Cargo buildpack for SBOM generation. This requires the syft CLI which is provided through the syft buildpack. This PR adds the syft buildpack to this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>