### PR TITLE
Update buildpack.toml

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.6"
+api = "0.7"
 
 [buildpack]
   description = "A Cloud Native Buildpack with an order definition suitable for Rust applications"


### PR DESCRIPTION
Bump buildpack API to 0.7.

I do not believe that this will impact anything with the buildpack. All the contained buildpacks have already been bumped, but this is just a composite buildpack anyway. It shouldn't care about the API version, as far as I know.