### PR TITLE
Add syft buildpack to update builder workflow

### DIFF
--- a/.github/workflows/update-example-builder.yml
+++ b/.github/workflows/update-example-builder.yml
@@ -110,6 +110,15 @@ jobs:
                   --id "${PROCFILE_DEPENDENCY}" \
                   --version "${NEW_PROCFILE_VERSION}"
 
+                # update syft
+                NEW_SYFT_VERSION=$(crane ls "${SYFT_DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
+                OLD_SYFT_VERSION=$(yj -tj < example-builder.toml | jq -r ".buildpacks[].uri | capture(\".*${SYFT_DEPENDENCY}:(?<version>.+)\") | .version")
+
+                update-package-dependency \
+                  --builder-toml example-builder.toml \
+                  --id "${SYFT_DEPENDENCY}" \
+                  --version "${NEW_SYFT_VERSION}"
+
                 git add example-builder.toml
                 git checkout -- .
 
@@ -121,11 +130,14 @@ jobs:
                 echo "::set-output name=new-rustup-version::${NEW_RUSTUP_VERSION}"
                 echo "::set-output name=old-procfile-version::${OLD_PROCFILE_VERSION}"
                 echo "::set-output name=new-procfile-version::${NEW_PROCFILE_VERSION}"
+                echo "::set-output name=old-syft-version::${OLD_SYFT_VERSION}"
+                echo "::set-output name=new-syft-version::${NEW_SYFT_VERSION}"
               env:
                 CARGO_DEPENDENCY: docker.io/paketocommunity/cargo
                 RUST_DIST_DEPENDENCY: docker.io/paketocommunity/rust-dist
                 RUSTUP_DEPENDENCY: docker.io/paketocommunity/rustup
                 PROCFILE_DEPENDENCY: gcr.io/paketo-buildpacks/procfile
+                SYFT_DEPENDENCY: gcr.io/paketo-buildpacks/syft
             - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }} <${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}@users.noreply.github.com>
@@ -136,6 +148,7 @@ jobs:
                     - Bump [`docker.io/paketocommunity/rust-dist`](https://hub.docker.com/r/paketocommunity/rust-dist) from ${{ steps.package.outputs.old-rust-dist-version }} to ${{ steps.package.outputs.new-rust-dist-version }}
                     - Bump [`docker.io/paketocommunity/rustup`](https://hub.docker.com/r/paketocommunity/rustup) from ${{ steps.package.outputs.old-rustup-version }} to ${{ steps.package.outputs.new-rustup-version }}
                     - Bump [`gcr.io/paketo-buildpacks/procfile`](https://gcr.io/paketo-buildpacks/procfile) from ${{ steps.package.outputs.old-procfile-version }} to ${{ steps.package.outputs.new-procfile-version }}
+                    - Bump [`gcr.io/paketo-buildpacks/syft`](https://gcr.io/paketo-buildpacks/syft) from ${{ steps.package.outputs.old-syft-version }} to ${{ steps.package.outputs.new-syft-version }}
                 branch: update/package/builder-example
                 commit-message: |-
                     Bumps `example-builder.toml`.
@@ -144,8 +157,9 @@ jobs:
                     - Bump docker.io/paketocommunity/rust-dist from ${{ steps.package.outputs.old-rust-dist-version }} to ${{ steps.package.outputs.new-rust-dist-version }}
                     - Bump docker.io/paketocommunity/rustup from ${{ steps.package.outputs.old-rustup-version }} to ${{ steps.package.outputs.new-rustup-version }}
                     - Bump gcr.io/paketo-buildpacks/procfile from ${{ steps.package.outputs.old-procfile-version }} to ${{ steps.package.outputs.new-procfile-version }}
+                    - Bump gcr.io/paketo-buildpacks/syft from ${{ steps.package.outputs.old-syft-version }} to ${{ steps.package.outputs.new-syft-version }}
                 delete-branch: true
                 labels: semver:minor, type:dependency-upgrade
                 signoff: true
-                title: Bump docker.io/paketocommunity/cargo from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}
+                title: Bump docker.io/paketocommunity/cargo Builder
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow updates the example builder. It was not watching for updates to the syft buildpack. This PR makes it watch for syft as well as the other buildpacks used in the builder.

Signed-off-by: Daniel Mikusa <dan@mikusa.com>
