### PR TITLE
Fixes publishing problem

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -9,7 +9,7 @@ codeowners:
   owner: "@paketo-community/rust-maintainers"
 
 package:
-  repositories:   ["docker.io/paketobuildpacks/rust","gcr.io/paketo-buildpacks/rust"]
+  repositories:   ["docker.io/paketocommunity/rust","gcr.io/paketo-community/rust"]
   register:       true
   registry_token: ${ secrets.PAKETO_BOT_GITHUB_TOKEN }
 

--- a/.github/workflows/pb-create-package.yml
+++ b/.github/workflows/pb-create-package.yml
@@ -195,7 +195,7 @@ jobs:
                     --format "${FORMAT}"
                 fi
               env:
-                PACKAGES: docker.io/paketobuildpacks/rust gcr.io/paketo-buildpacks/rust
+                PACKAGES: docker.io/paketocommunity/rust gcr.io/paketo-community/rust
                 PUBLISH: "true"
                 VERSION: ${{ steps.version.outputs.version }}
                 VERSION_MAJOR: ${{ steps.version.outputs.version-major }}
@@ -225,7 +225,7 @@ jobs:
             - if: ${{ true }}
               uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.1
               with:
-                address: docker.io/paketobuildpacks/rust@${{ steps.package.outputs.digest }}
+                address: docker.io/paketocommunity/rust@${{ steps.package.outputs.digest }}
                 id: paketo-community/rust
                 token: ${ secrets.PAKETO_BOT_GITHUB_TOKEN }
                 version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -10,6 +10,20 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
+            - name: Docker login gcr.io
+              if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
+              uses: docker/login-action@v2
+              with:
+                password: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
+                registry: gcr.io
+                username: _json_key
+            - name: Docker login docker.io
+              if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
+              uses: docker/login-action@v2
+              with:
+                password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
+                registry: docker.io
+                username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
             - uses: actions/setup-go@v3
               with:
                 go-version: "1.18"


### PR DESCRIPTION
The recent PR to update to publish to docker wrote the wrong docker registry address. This changes it back to `paketocommunity/`.

Signed-off-by: Daniel Mikusa <dan@mikusa.com>
